### PR TITLE
Dockerfile: fix BASE_IMAGE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,16 @@ ARG BASE_IMAGE
 RUN apt-get -qq update && apt-get -qq install -y git
 RUN git clone https://github.com/panda-re/panda /panda/
 
+# syz-rrr: instead of copying we take it from the clone just above
+# Copy dependencies lists into container. We copy them all and then do a mv because
+# we need to transform base_image into a windows compatible filename which we can't
+# do in a COPY command.
+RUN cp /panda/panda/dependencies/* /tmp
+RUN mv /tmp/$(echo "$BASE_IMAGE" | sed 's/:/_/g')_build.txt /tmp/build_dep.txt && \
+    mv /tmp/$(echo "$BASE_IMAGE" | sed 's/:/_/g')_base.txt /tmp/base_dep.txt
+
 # Base image just needs runtime dependencies
-RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -y --no-install-recommends curl $(cat /panda/panda/dependencies/${BASE_IMAGE}_base.txt | grep -o '^[^#]*') && \
+RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install -y --no-install-recommends curl $(cat /tmp/base_dep.txt | grep -o '^[^#]*') && \
     apt-get clean
 
 ### BUILD IMAGE - STAGE 2
@@ -20,7 +28,7 @@ ARG BASE_IMAGE
 ARG TARGET_LIST
 
 RUN apt-get -qq update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $(cat /panda/panda/dependencies/${BASE_IMAGE}_build.txt | grep -o '^[^#]*') && \
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $(cat /tmp/build_dep.txt | grep -o '^[^#]*') && \
     apt-get clean && \
     python3 -m pip install --upgrade --no-cache-dir pip && \
     python3 -m pip install --upgrade --no-cache-dir "cffi>1.14.3" && \
@@ -56,7 +64,9 @@ RUN git -C /panda submodule update --init dtc && \
         --disable-numa \
         --enable-llvm \
         --extra-cflags="-Wno-error=deprecated-declarations" && \
-    (make -C /panda/build -j "$(nproc)" || make) # If multi-core make fails, remake once to give a good error at the end
+    rm -rf /panda/.git
+
+RUN make -C /panda/build -j "$(nproc)"
 
 #### Develop setup: panda built + pypanda installed (in develop mode) - Stage 3
 FROM builder as developer
@@ -72,7 +82,13 @@ WORKDIR /panda/
 
 #### Install PANDA + pypanda from builder - Stage 4
 FROM builder as installer
-RUN  make -C /panda/build install
+RUN  make -C /panda/build install && \
+    rm -r /usr/local/lib/panda/*/cosi \
+        /usr/local/lib/panda/*/cosi_strace \
+        /usr/local/lib/panda/*/gdb \
+        /usr/local/lib/panda/*/snake_hook \
+        /usr/local/lib/panda/*/rust_skeleton
+
 # Install pypanda
 RUN cd /panda/panda/python/core && \
     python3 setup.py install
@@ -82,13 +98,33 @@ RUN python3 -m pip install --ignore-install pycparser && python3 -m pip install 
 RUN ls -alt $(pip show pandare | grep Location: | awk '{print $2}')/pandare/autogen/
 RUN bash -c "ls $(pip show pandare | grep Location: | awk '{print $2}')/pandare/autogen/panda_{aarch64_64,arm_32,mips64_64,mips_32,mipsel_32,ppc_32,ppc_64,x86_64_64,i386_32}.py"
 
+# this layer is used to strip shared objects and change python data to be
+# symlinks to the installed panda data directory
+FROM installer as cleanup
+RUN find /usr/local/lib/panda -name "*.so" -exec strip {} \;
+RUN PKG=`pip show pandare | grep Location: | awk '{print $2}'`/pandare/data; \
+    rm -rf $PKG/pc-bios && ln -s /usr/local/share/panda $PKG/pc-bios; \
+    for arch in `find $PKG -name "*-softmmu" -type d -exec basename {} \;` ; do \
+        ARCHP=$PKG/$arch; \
+        SARCH=`echo $arch | cut -d'-' -f 1`; \
+        rm $ARCHP/libpanda-$SARCH.so $ARCHP/llvm-helpers-$SARCH.bc; \
+        ln -s /usr/local/share/panda/llvm-helpers-$SARCH.bc $ARCHP/llvm-helpers-$SARCH.bc1; \
+        ln -s /usr/local/bin/libpanda-$SARCH.so $ARCHP/libpanda-$SARCH.so; \
+        rm -rf $ARCHP/panda/plugins; \
+        ln -s /usr/local/lib/panda/$SARCH/ $ARCHP/panda/plugins; \
+    done
+
 ### Copy files for panda+pypanda from installer  - Stage 5
 FROM base as panda
 
+# Include dependency lists for packager
+COPY --from=base /tmp/base_dep.txt /tmp
+COPY --from=base /tmp/build_dep.txt /tmp
+
 # Copy panda + libcapstone.so* + libosi libraries
-COPY --from=installer /usr/local /usr/local
-COPY --from=installer /usr/lib/libcapstone* /usr/lib/
-COPY --from=installer /lib/libosi.so /lib/libiohal.so /lib/liboffset.so /lib/
+COPY --from=cleanup /usr/local /usr/local
+COPY --from=cleanup /usr/lib/libcapstone* /usr/lib/
+COPY --from=cleanup /lib/libosi.so /lib/libiohal.so /lib/liboffset.so /lib/
 
 # Workaround issue #901 - ensure LD_LIBRARY_PATH contains the panda plugins directories
 ENV LD_LIBRARY_PATH /usr/local/lib/python3.8/dist-packages/pandare/data/x86_64-softmmu/panda/plugins/:/usr/local/lib/python3.8/dist-packages/pandare/data/i386-softmmu/panda/plugins/:/usr/local/lib/python3.8/dist-packages/pandare/data/arm-softmmu/panda/plugins/:/usr/local/lib/python3.8/dist-packages/pandare/data/ppc-softmmu/panda/plugins/:/usr/local/lib/python3.8/dist-packages/pandare/data/mips-softmmu/panda/plugins/:/usr/local/lib/python3.8/dist-packages/pandare/data/mipsel-softmmu/panda/plugins/


### PR DESCRIPTION
The `BASE_IMAGE` required for panda includes an underscore while the `BASE_IMAGE` for the docker container requires a colon.

Tried a few things to not have it as two definitions but failed with `sh` and `Dockerfile`.