### PR TITLE
jupyter: fix calling replay()

### DIFF
--- a/rrr.ipynb
+++ b/rrr.ipynb
@@ -134,7 +134,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rrr.replay(record)"
+    "rrr.replay(rootfs, record)"
    ]
   }
  ],


### PR DESCRIPTION
Jupyter notebook also needs to call the correct signature of `replay()`