### PR TITLE
Remove redundant EXPOSE commands from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -153,5 +153,3 @@ RUN pip install --no-cache-dir --upgrade pip jupyter protobuf pandas lxml pygdbm
 # Start the jupyter server automatically
 ENV SHELL=/bin/bash
 CMD jupyter notebook --allow-root --no-browser --ip=* --NotebookApp.token=rrr
-EXPOSE 8888
-EXPOSE 9001


### PR DESCRIPTION
The EXPOSE commands used by docker to expose ports which eventually could be useful when ports publishing is done. As syz-rrr runs in network host mode, all ports are published automatically and there is no need to expose them before.